### PR TITLE
fix: compute quartile indices dynamically instead of hardcoding 25/75

### DIFF
--- a/rosplane/src/ekf/estimator_ros.cpp
+++ b/rosplane/src/ekf/estimator_ros.cpp
@@ -323,8 +323,15 @@ void EstimatorROS::update_barometer_calibration(const rosflight_msgs::msg::Barom
 
     //Check that it got a good calibration.
     std::sort(init_static_vector_.begin(), init_static_vector_.end());
-    float q1 = (init_static_vector_[24] + init_static_vector_[25]) / 2.0;
-    float q3 = (init_static_vector_[74] + init_static_vector_[75]) / 2.0;
+
+    int n = init_static_vector_.size();
+    
+    int q1_index = n / 4 - 1;       // equivalent to 25 when n=100 (since 100/4 - 1 = 24)
+    int q3_index = (3 * n) / 4 - 1; // equivalent to 74 when n=100 (since 300/4 - 1 = 74)
+
+    float q1 = (init_static_vector_[q1_index] + init_static_vector_[q1_index+1]) / 2.0;
+    float q3 = (init_static_vector_[q3_index] + init_static_vector_[q3_index+1]) / 2.0;
+
     float IQR = q3 - q1;
     float upper_bound = q3 + 2.0 * IQR;
     float lower_bound = q1 - 2.0 * IQR;


### PR DESCRIPTION
## Description
Fixes hardcoded Q1/Q3 indices (24/25, 74/75) in barometer calibration
outlier detection. These were hardcoded assuming a vector of exactly
100 elements, which breaks when `baro_calibration_count` is changed
from its default of 100.

## Changes
- Compute q1_index and q3_index dynamically based on the size of
  `init_static_vector_`, instead of hardcoded constants.

## Testing
- Verified the new formula produces identical results to the original
  hardcoded indices when n=100 (no behavior change at default config)
- Verified no out-of-bounds access / correct scaling for n=50 and n=200
  via a standalone test of the quartile logic

Closes #95 